### PR TITLE
stop using the outdated /browse path

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -1419,7 +1419,7 @@ function renderChangesetsList(changesetsToDisplay) {
     //Changeset comment
     rl.append('a')
         .classed('changeset-comment', true)
-        .attr('href', d => `https://openstreetmap.org/browse/changeset/${d.id}`)
+        .attr('href', d => `https://www.openstreetmap.org/changeset/${d.id}`)
         .attr('target', '_blank')
         .attr('title', d => `Go to OSM changeset page\n\n${changesets[d.id].comment}`)
         //Changeset title (was downloaded separately from OSM API)


### PR DESCRIPTION
Currently, openstreetmap-website is redirecting and there was discussion about removing these redirects. They are unlikely to be removed, but in any case the URL will look a little nicer.