### PR TITLE
feat: Add pre-download OSM key filters.

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -655,6 +655,81 @@ below the long text would expand the table width. */
   background-color: #008dff;
 }
 
+.key-filter {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.key-filter-checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.key-filter-chip {
+  flex: 1 1 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-width: 0;
+  height: 32px;
+  padding: 0 4px;
+  border: 1px solid #c5d0dc;
+  border-radius: 16px;
+  background: #ffffff;
+  color: #4a5563;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.key-filter-icon {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+}
+
+.key-filter-chip:hover {
+  border-color: #008dff;
+  color: #008dff;
+}
+
+#filter-key-building:focus-visible + .key-building,
+#filter-key-highway:focus-visible + .key-highway,
+#filter-key-landuse:focus-visible + .key-landuse {
+  outline: 2px solid #008dff;
+  outline-offset: 2px;
+}
+
+#filter-key-building:checked + .key-building {
+  background-color: #c47d3b;
+  border-color: #c47d3b;
+  color: #fff;
+  box-shadow: 0 2px 6px rgba(196, 125, 59, 0.35);
+}
+
+#filter-key-highway:checked + .key-highway {
+  background-color: #c84b4b;
+  border-color: #c84b4b;
+  color: #fff;
+  box-shadow: 0 2px 6px rgba(200, 75, 75, 0.35);
+}
+
+#filter-key-landuse:checked + .key-landuse {
+  background-color: #5a9a3a;
+  border-color: #5a9a3a;
+  color: #fff;
+  box-shadow: 0 2px 6px rgba(90, 154, 58, 0.35);
+}
+
 /* #endregion */
 
 /* #region CSS RELATED TO LEAFLET MAP LAYOUT */

--- a/css/site.css
+++ b/css/site.css
@@ -671,8 +671,8 @@ below the long text would expand the table width. */
 
 .key-filter {
   display: flex;
-  align-items: stretch;
-  gap: 6px;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .key-filter-checkbox {
@@ -683,25 +683,22 @@ below the long text would expand the table width. */
   pointer-events: none;
 }
 
-.key-filter-chip {
-  flex: 1 1 0;
-  display: inline-flex;
+.key-filter-row {
+  display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 4px;
+  gap: 8px;
   min-width: 0;
   height: 32px;
-  padding: 0 4px;
-  border: 1px solid #c5d0dc;
-  border-radius: 16px;
+  padding: 0 8px;
+  border: 1px solid #d5dbe3;
+  border-radius: 8px;
   background: #ffffff;
   color: #4a5563;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
-  letter-spacing: 0.01em;
   cursor: pointer;
   user-select: none;
-  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
 }
 
 .key-filter-icon {
@@ -710,27 +707,50 @@ below the long text would expand the table width. */
   flex: 0 0 14px;
 }
 
-.key-filter-chip:hover {
+.key-filter-name {
+  flex: 1 1 auto;
+}
+
+.key-switch {
+  position: relative;
+  flex: 0 0 36px;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  background: #c5cdd6;
+  transition: background-color 0.2s ease;
+}
+
+.key-switch-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  transition: transform 0.2s ease;
+}
+
+.key-filter-row:hover {
   border-color: #008dff;
   color: #008dff;
 }
 
-.key-filter-wrap.is-locked .key-filter-chip:not(.is-downloaded) {
-  background: #eceff3;
-  border-color: #d5dbe3;
+.key-filter-wrap.is-locked .key-filter-row:not(.is-downloaded) {
+  background: #f3f5f7;
+  border-color: #e1e6ec;
   color: #9aa3ad;
-  box-shadow: none;
-  filter: grayscale(1);
-  opacity: 0.45;
-  cursor: pointer;
+  opacity: 0.55;
 }
 
-.key-filter-wrap.is-locked .key-filter-chip:not(.is-downloaded):hover {
-  border-color: #d5dbe3;
+.key-filter-wrap.is-locked .key-filter-row:not(.is-downloaded):hover {
+  border-color: #e1e6ec;
   color: #9aa3ad;
 }
 
-.key-filter-wrap.is-downloading .key-filter-chip {
+.key-filter-wrap.is-downloading .key-filter-row {
   pointer-events: none;
   cursor: wait;
 }
@@ -742,25 +762,22 @@ below the long text would expand the table width. */
   outline-offset: 2px;
 }
 
-#filter-key-building:checked + .key-building {
-  background-color: #c47d3b;
-  border-color: #c47d3b;
-  color: #fff;
-  box-shadow: 0 2px 6px rgba(196, 125, 59, 0.35);
+#filter-key-building:checked + .key-building .key-switch {
+  background: #c47d3b;
 }
 
-#filter-key-highway:checked + .key-highway {
-  background-color: #c84b4b;
-  border-color: #c84b4b;
-  color: #fff;
-  box-shadow: 0 2px 6px rgba(200, 75, 75, 0.35);
+#filter-key-highway:checked + .key-highway .key-switch {
+  background: #c84b4b;
 }
 
-#filter-key-landuse:checked + .key-landuse {
-  background-color: #5a9a3a;
-  border-color: #5a9a3a;
-  color: #fff;
-  box-shadow: 0 2px 6px rgba(90, 154, 58, 0.35);
+#filter-key-landuse:checked + .key-landuse .key-switch {
+  background: #5a9a3a;
+}
+
+#filter-key-building:checked + .key-building .key-switch-knob,
+#filter-key-highway:checked + .key-highway .key-switch-knob,
+#filter-key-landuse:checked + .key-landuse .key-switch-knob {
+  transform: translateX(16px);
 }
 
 /* #endregion */

--- a/css/site.css
+++ b/css/site.css
@@ -755,11 +755,16 @@ below the long text would expand the table width. */
   cursor: wait;
 }
 
+#filter-key-all:focus-visible + .key-all,
 #filter-key-building:focus-visible + .key-building,
 #filter-key-highway:focus-visible + .key-highway,
 #filter-key-landuse:focus-visible + .key-landuse {
   outline: 2px solid #008dff;
   outline-offset: 2px;
+}
+
+#filter-key-all:checked + .key-all .key-switch {
+  background: #008dff;
 }
 
 #filter-key-building:checked + .key-building .key-switch {
@@ -774,6 +779,7 @@ below the long text would expand the table width. */
   background: #5a9a3a;
 }
 
+#filter-key-all:checked + .key-all .key-switch-knob,
 #filter-key-building:checked + .key-building .key-switch-knob,
 #filter-key-highway:checked + .key-highway .key-switch-knob,
 #filter-key-landuse:checked + .key-landuse .key-switch-knob {

--- a/css/site.css
+++ b/css/site.css
@@ -655,11 +655,24 @@ below the long text would expand the table width. */
   background-color: #008dff;
 }
 
+.key-filter-wrap {
+  width: 95%;
+  max-width: 400px;
+  margin: 0 auto 10px;
+}
+
+.key-filter-caption {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #6b7280;
+  margin: 0 2px 5px;
+}
+
 .key-filter {
   display: flex;
   align-items: stretch;
   gap: 6px;
-  margin-top: 8px;
 }
 
 .key-filter-checkbox {

--- a/css/site.css
+++ b/css/site.css
@@ -715,6 +715,26 @@ below the long text would expand the table width. */
   color: #008dff;
 }
 
+.key-filter-wrap.is-locked .key-filter-chip:not(.is-downloaded) {
+  background: #eceff3;
+  border-color: #d5dbe3;
+  color: #9aa3ad;
+  box-shadow: none;
+  filter: grayscale(1);
+  opacity: 0.45;
+  cursor: pointer;
+}
+
+.key-filter-wrap.is-locked .key-filter-chip:not(.is-downloaded):hover {
+  border-color: #d5dbe3;
+  color: #9aa3ad;
+}
+
+.key-filter-wrap.is-downloading .key-filter-chip {
+  pointer-events: none;
+  cursor: wait;
+}
+
 #filter-key-building:focus-visible + .key-building,
 #filter-key-highway:focus-visible + .key-highway,
 #filter-key-landuse:focus-visible + .key-landuse {

--- a/img/icons.svg
+++ b/img/icons.svg
@@ -29,4 +29,19 @@ d="m280,278a153,153 0 1,0-2,2l170,170m-91-117 110,110-26,26-110-110"/>
 <!-- Arrow up -->
 <symbol id="arrow-up" class="random" focusable="false" width="24" height="24" viewBox="0 0 24 24"><path d="M12 16.41l-6.71-6.7 1.42-1.42 5.29 5.3 5.29-5.3 1.42 1.42z"></path></symbol>
 
+<!-- OSM key: building -->
+<symbol id="key-building" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M4 21V9.5L12 3l8 6.5V21h-6v-6H10v6H4zm2-2h2v-6h8v6h2v-8.4l-6-4.9-6 4.9V19z"/>
+</symbol>
+
+<!-- OSM key: highway -->
+<symbol id="key-highway" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M5 3h14l-2.2 18H7.2L5 3zm3.1 2-.3 2.4h8.4L16 5H8.1zm-.5 4.4-.3 2.4h9.4l-.3-2.4H7.6zm.6 8.4.3-2.4H15.5l.3 2.4H8.2z"/>
+</symbol>
+
+<!-- OSM key: landuse -->
+<symbol id="key-landuse" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M12 3.5 7 11h10L12 3.5zM4 20h7v-6.5L4 20zm9 0h7l-7-6.5V20z"/>
+</symbol>
+
 </svg>

--- a/img/icons.svg
+++ b/img/icons.svg
@@ -29,6 +29,11 @@ d="m280,278a153,153 0 1,0-2,2l170,170m-91-117 110,110-26,26-110-110"/>
 <!-- Arrow up -->
 <symbol id="arrow-up" class="random" focusable="false" width="24" height="24" viewBox="0 0 24 24"><path d="M12 16.41l-6.71-6.7 1.42-1.42 5.29 5.3 5.29-5.3 1.42 1.42z"></path></symbol>
 
+<!-- OSM key: all -->
+<symbol id="key-all" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M4 4h7v7H4V4zm9 0h7v7h-7V4zM4 13h7v7H4v-7zm9 0h7v7h-7v-7z"/>
+</symbol>
+
 <!-- OSM key: building -->
 <symbol id="key-building" viewBox="0 0 24 24">
   <path fill="currentColor" d="M4 21V9.5L12 3l8 6.5V21h-6v-6H10v6H4zm2-2h2v-6h8v6h2v-8.4l-6-4.9-6 4.9V19z"/>

--- a/index.html
+++ b/index.html
@@ -93,6 +93,35 @@
             <option value="7" selected>Last 7 Days</option>
             <option value="30">Last 30 Days</option>
           </select>
+          <div class="key-filter-wrap">
+            <div class="key-filter-caption">Only download these keys</div>
+            <div class="key-filter" role="group" aria-label="Only download changes for these OSM keys">
+              <input type="checkbox" id="filter-key-building" class="key-filter-checkbox" data-key="building">
+              <label for="filter-key-building" class="key-filter-chip key-building"
+                title="Only download changes that touch the building key">
+                <svg class="key-filter-icon" aria-hidden="true">
+                  <use href="img/icons.svg#key-building"></use>
+                </svg>
+                <span>building</span>
+              </label>
+              <input type="checkbox" id="filter-key-highway" class="key-filter-checkbox" data-key="highway">
+              <label for="filter-key-highway" class="key-filter-chip key-highway"
+                title="Only download changes that touch the highway key">
+                <svg class="key-filter-icon" aria-hidden="true">
+                  <use href="img/icons.svg#key-highway"></use>
+                </svg>
+                <span>highway</span>
+              </label>
+              <input type="checkbox" id="filter-key-landuse" class="key-filter-checkbox" data-key="landuse">
+              <label for="filter-key-landuse" class="key-filter-chip key-landuse"
+                title="Only download changes that touch the landuse key">
+                <svg class="key-filter-icon" aria-hidden="true">
+                  <use href="img/icons.svg#key-landuse"></use>
+                </svg>
+                <span>landuse</span>
+              </label>
+            </div>
+          </div>
           <button id="download-changesets-button" title="Get recent changesets in this region">
             <svg class="circular-arrow">
               <use href="img/icons.svg#circular-arrow"></use>
@@ -116,32 +145,6 @@
                 </svg>
               </div>
               <input type="text" class="search-changesets-field" placeholder="Filter changesets">
-            </div>
-            <div class="key-filter" role="group" aria-label="Filter by OSM key">
-              <input type="checkbox" id="filter-key-building" class="key-filter-checkbox" data-key="building">
-              <label for="filter-key-building" class="key-filter-chip key-building"
-                title="Only show changes that touch the building key">
-                <svg class="key-filter-icon" aria-hidden="true">
-                  <use href="img/icons.svg#key-building"></use>
-                </svg>
-                <span>building</span>
-              </label>
-              <input type="checkbox" id="filter-key-highway" class="key-filter-checkbox" data-key="highway">
-              <label for="filter-key-highway" class="key-filter-chip key-highway"
-                title="Only show changes that touch the highway key">
-                <svg class="key-filter-icon" aria-hidden="true">
-                  <use href="img/icons.svg#key-highway"></use>
-                </svg>
-                <span>highway</span>
-              </label>
-              <input type="checkbox" id="filter-key-landuse" class="key-filter-checkbox" data-key="landuse">
-              <label for="filter-key-landuse" class="key-filter-chip key-landuse"
-                title="Only show changes that touch the landuse key">
-                <svg class="key-filter-icon" aria-hidden="true">
-                  <use href="img/icons.svg#key-landuse"></use>
-                </svg>
-                <span>landuse</span>
-              </label>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -117,6 +117,32 @@
               </div>
               <input type="text" class="search-changesets-field" placeholder="Filter changesets">
             </div>
+            <div class="key-filter" role="group" aria-label="Filter by OSM key">
+              <input type="checkbox" id="filter-key-building" class="key-filter-checkbox" data-key="building">
+              <label for="filter-key-building" class="key-filter-chip key-building"
+                title="Only show changes that touch the building key">
+                <svg class="key-filter-icon" aria-hidden="true">
+                  <use href="img/icons.svg#key-building"></use>
+                </svg>
+                <span>building</span>
+              </label>
+              <input type="checkbox" id="filter-key-highway" class="key-filter-checkbox" data-key="highway">
+              <label for="filter-key-highway" class="key-filter-chip key-highway"
+                title="Only show changes that touch the highway key">
+                <svg class="key-filter-icon" aria-hidden="true">
+                  <use href="img/icons.svg#key-highway"></use>
+                </svg>
+                <span>highway</span>
+              </label>
+              <input type="checkbox" id="filter-key-landuse" class="key-filter-checkbox" data-key="landuse">
+              <label for="filter-key-landuse" class="key-filter-chip key-landuse"
+                title="Only show changes that touch the landuse key">
+                <svg class="key-filter-icon" aria-hidden="true">
+                  <use href="img/icons.svg#key-landuse"></use>
+                </svg>
+                <span>landuse</span>
+              </label>
+            </div>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
   <!-- Style related -->
   <!-- <link rel="stylesheet" href="//unpkg.com/leaflet@1.7.1/dist/leaflet.css"> -->
   <link rel="stylesheet" href="./css/leaflet.css">
-  <link rel='stylesheet' type='text/css' href='css/site.css?v=20260818d' />
+  <link rel='stylesheet' type='text/css' href='css/site.css?v=20260818e' />
   <link rel="stylesheet" href="//unpkg.com/leaflet-gesture-handling/dist/leaflet-gesture-handling.min.css"
     type="text/css">
   <link rel="stylesheet"
@@ -74,7 +74,7 @@
   <script src='js/osmtogeojson.js' defer></script>
 
   <!-- Application script - MUST BE LAST since it depends on the others -->
-  <script src='js/site.js?v=20260818d' defer></script>
+  <script src='js/site.js?v=20260818e' defer></script>
 </head>
 
 <body>
@@ -96,6 +96,15 @@
           <div class="key-filter-wrap">
             <div class="key-filter-caption">Select keys before download</div>
             <div class="key-filter" role="group" aria-label="Only download changes for these OSM keys">
+              <input type="checkbox" id="filter-key-all" class="key-filter-checkbox" data-key="all" checked>
+              <label for="filter-key-all" class="key-filter-row key-all"
+                title="Download all changes, without filtering by OSM key">
+                <svg class="key-filter-icon" aria-hidden="true">
+                  <use href="img/icons.svg#key-all"></use>
+                </svg>
+                <span class="key-filter-name">all</span>
+                <span class="key-switch" aria-hidden="true"><span class="key-switch-knob"></span></span>
+              </label>
               <input type="checkbox" id="filter-key-building" class="key-filter-checkbox" data-key="building">
               <label for="filter-key-building" class="key-filter-row key-building"
                 title="Only download changes that touch the building key">

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
   <!-- Style related -->
   <!-- <link rel="stylesheet" href="//unpkg.com/leaflet@1.7.1/dist/leaflet.css"> -->
   <link rel="stylesheet" href="./css/leaflet.css">
-  <link rel='stylesheet' type='text/css' href='css/site.css?v=20260818c' />
+  <link rel='stylesheet' type='text/css' href='css/site.css?v=20260818d' />
   <link rel="stylesheet" href="//unpkg.com/leaflet-gesture-handling/dist/leaflet-gesture-handling.min.css"
     type="text/css">
   <link rel="stylesheet"
@@ -74,7 +74,7 @@
   <script src='js/osmtogeojson.js' defer></script>
 
   <!-- Application script - MUST BE LAST since it depends on the others -->
-  <script src='js/site.js?v=20260818c' defer></script>
+  <script src='js/site.js?v=20260818d' defer></script>
 </head>
 
 <body>
@@ -97,28 +97,31 @@
             <div class="key-filter-caption">Select keys before download</div>
             <div class="key-filter" role="group" aria-label="Only download changes for these OSM keys">
               <input type="checkbox" id="filter-key-building" class="key-filter-checkbox" data-key="building">
-              <label for="filter-key-building" class="key-filter-chip key-building"
+              <label for="filter-key-building" class="key-filter-row key-building"
                 title="Only download changes that touch the building key">
                 <svg class="key-filter-icon" aria-hidden="true">
                   <use href="img/icons.svg#key-building"></use>
                 </svg>
-                <span>building</span>
+                <span class="key-filter-name">building</span>
+                <span class="key-switch" aria-hidden="true"><span class="key-switch-knob"></span></span>
               </label>
               <input type="checkbox" id="filter-key-highway" class="key-filter-checkbox" data-key="highway">
-              <label for="filter-key-highway" class="key-filter-chip key-highway"
+              <label for="filter-key-highway" class="key-filter-row key-highway"
                 title="Only download changes that touch the highway key">
                 <svg class="key-filter-icon" aria-hidden="true">
                   <use href="img/icons.svg#key-highway"></use>
                 </svg>
-                <span>highway</span>
+                <span class="key-filter-name">highway</span>
+                <span class="key-switch" aria-hidden="true"><span class="key-switch-knob"></span></span>
               </label>
               <input type="checkbox" id="filter-key-landuse" class="key-filter-checkbox" data-key="landuse">
-              <label for="filter-key-landuse" class="key-filter-chip key-landuse"
+              <label for="filter-key-landuse" class="key-filter-row key-landuse"
                 title="Only download changes that touch the landuse key">
                 <svg class="key-filter-icon" aria-hidden="true">
                   <use href="img/icons.svg#key-landuse"></use>
                 </svg>
-                <span>landuse</span>
+                <span class="key-filter-name">landuse</span>
+                <span class="key-switch" aria-hidden="true"><span class="key-switch-knob"></span></span>
               </label>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
   <!-- Style related -->
   <!-- <link rel="stylesheet" href="//unpkg.com/leaflet@1.7.1/dist/leaflet.css"> -->
   <link rel="stylesheet" href="./css/leaflet.css">
-  <link rel='stylesheet' type='text/css' href='css/site.css' />
+  <link rel='stylesheet' type='text/css' href='css/site.css?v=20260818c' />
   <link rel="stylesheet" href="//unpkg.com/leaflet-gesture-handling/dist/leaflet-gesture-handling.min.css"
     type="text/css">
   <link rel="stylesheet"
@@ -74,7 +74,7 @@
   <script src='js/osmtogeojson.js' defer></script>
 
   <!-- Application script - MUST BE LAST since it depends on the others -->
-  <script src='js/site.js' defer></script>
+  <script src='js/site.js?v=20260818c' defer></script>
 </head>
 
 <body>
@@ -94,7 +94,7 @@
             <option value="30">Last 30 Days</option>
           </select>
           <div class="key-filter-wrap">
-            <div class="key-filter-caption">Only download these keys</div>
+            <div class="key-filter-caption">Select keys before download</div>
             <div class="key-filter" role="group" aria-label="Only download changes for these OSM keys">
               <input type="checkbox" id="filter-key-building" class="key-filter-checkbox" data-key="building">
               <label for="filter-key-building" class="key-filter-chip key-building"

--- a/js/site.js
+++ b/js/site.js
@@ -299,23 +299,81 @@ function getSelectedOsmKeys() {
     });
 }
 
+function keysFromUrl() {
+    const raw = new URLSearchParams(location.search).get('keys') || '';
+    return raw.split(',').map(key => key.trim()).filter(key => OSM_KEY_FILTERS.includes(key));
+}
+
+function syncOsmKeysInUrl(keys) {
+    const url = new URL(location.href);
+    if (keys.length) url.searchParams.set('keys', keys.join(','));
+    else url.searchParams.delete('keys');
+    history.replaceState(history.state, '', url);
+}
+
+function setKeyFilterCaption(text) {
+    const caption = document.querySelector('.key-filter-caption');
+    if (caption) caption.textContent = text;
+}
+
 function persistOsmKeyFilters() {
-    localStorage.setItem('osm-key-filters', JSON.stringify(getSelectedOsmKeys()));
+    const keys = getSelectedOsmKeys();
+    localStorage.setItem('osm-key-filters', JSON.stringify(keys));
+    syncOsmKeysInUrl(keys);
 }
 
 function restoreOsmKeyFilters() {
-    const stored = localStorage.getItem('osm-key-filters');
-    if (!stored) return;
-    try {
-        const keys = JSON.parse(stored);
-        if (!Array.isArray(keys)) return;
-        OSM_KEY_FILTERS.forEach(key => {
-            const checkbox = document.getElementById('filter-key-' + key);
-            if (checkbox) checkbox.checked = keys.includes(key);
-        });
-    } catch (e) {
-        // Ignore invalid localStorage content
+    let keys = keysFromUrl();
+    if (!keys.length) {
+        const stored = localStorage.getItem('osm-key-filters');
+        if (stored) {
+            try {
+                const parsed = JSON.parse(stored);
+                if (Array.isArray(parsed)) {
+                    keys = parsed.filter(key => OSM_KEY_FILTERS.includes(key));
+                }
+            } catch (e) {
+                // Ignore invalid localStorage content
+            }
+        }
     }
+    OSM_KEY_FILTERS.forEach(key => {
+        const checkbox = document.getElementById('filter-key-' + key);
+        if (checkbox) checkbox.checked = keys.includes(key);
+    });
+    persistOsmKeyFilters();
+}
+
+function lockUnusedKeyFilters(downloadedKeys, downloading = false) {
+    const wrap = document.querySelector('.key-filter-wrap');
+    wrap.classList.toggle('is-downloading', downloading);
+    wrap.classList.toggle('is-locked', downloadedKeys.length > 0);
+    OSM_KEY_FILTERS.forEach(key => {
+        const chip = document.querySelector('label[for="filter-key-' + key + '"]');
+        const used = downloadedKeys.includes(key);
+        chip.classList.toggle('is-downloaded', used);
+        chip.title = used
+            ? 'Included in this download'
+            : downloadedKeys.length
+                ? 'Not downloaded. Click to include in the next download'
+                : 'Only download changes that touch the ' + key + ' key';
+    });
+    if (downloadedKeys.length) {
+        setKeyFilterCaption('Downloaded: ' + downloadedKeys.join(', '));
+    } else {
+        setKeyFilterCaption('Select keys before download');
+    }
+}
+
+function unlockKeyFiltersForEditing() {
+    const wrap = document.querySelector('.key-filter-wrap');
+    wrap.classList.remove('is-locked', 'is-downloading');
+    document.querySelectorAll('.key-filter-chip').forEach(chip => chip.classList.remove('is-downloaded'));
+    OSM_KEY_FILTERS.forEach(key => {
+        const chip = document.querySelector('label[for="filter-key-' + key + '"]');
+        chip.title = 'Only download changes that touch the ' + key + ' key';
+    });
+    setKeyFilterCaption('Select keys before download');
 }
 
 // Build the Overpass adiff query. Selected keys are applied server-side so unused objects are never downloaded.
@@ -347,6 +405,9 @@ function run() {
     document.querySelector("#results").innerHTML = "";//Empty old results list (same happens in renderChangeSetsList() later on when filtering)
 
     toggleWaitingScreen();//Show loading animation and make download button unavailable
+    const requestedKeys = getSelectedOsmKeys();
+    persistOsmKeyFilters();
+    lockUnusedKeyFilters(requestedKeys, true);
 
     // 1. Abort previous request if it exists
     if (window.currentAbortController) {
@@ -393,7 +454,7 @@ function run() {
         // Try each server in sequence until one succeeds
         const tryServer = (index) => {
             const server = servers[index];
-            const url = server + 'interpreter?data=' + query;
+            const url = server + 'interpreter?data=' + encodeURIComponent(query);
             console.log(`Trying Overpass server ${index + 1}/${servers.length}: ${server}`);
 
             return fetch(url, { signal: signal })
@@ -656,6 +717,7 @@ function run() {
             //Change app display from "loading" to "ready"
             d3.select('#map').classed('faded', false);
             toggleWaitingScreen();
+            lockUnusedKeyFilters(requestedKeys, false);
 
             //Display filter changesets toolbar
             document.querySelector(".filter-container").classList.remove("hide");
@@ -1286,6 +1348,7 @@ function run() {
             } else {
                 // Handle actual network or processing errors
                 toggleWaitingScreen(); // Ensure loading screen is off
+                unlockKeyFiltersForEditing();
                 console.error("Error fetching or processing data:", error); // Log the actual error
                 message("alarm", "Server error: " + (error.message || "Could not load data."));
             }
@@ -2069,8 +2132,15 @@ document.querySelector("#filter-red-checkbox").addEventListener("click", (e) => 
     filterChangesets();
 });
 
-// OSM key chips are query parameters: persist them and apply on the next download
+// OSM key chips are query parameters: persist them in the URL and apply on the next download
 document.querySelectorAll(".key-filter-checkbox").forEach(checkbox => {
+    checkbox.addEventListener("click", () => {
+        const wrap = document.querySelector('.key-filter-wrap');
+        if (wrap.classList.contains('is-locked')) {
+            unlockKeyFiltersForEditing();
+            setKeyFilterCaption('Click Get Changesets to apply');
+        }
+    });
     checkbox.addEventListener("change", persistOsmKeyFilters);
 });
 

--- a/js/site.js
+++ b/js/site.js
@@ -368,7 +368,7 @@ function lockUnusedKeyFilters(downloadedKeys, downloading = false) {
 function unlockKeyFiltersForEditing() {
     const wrap = document.querySelector('.key-filter-wrap');
     wrap.classList.remove('is-locked', 'is-downloading');
-    document.querySelectorAll('.key-filter-chip').forEach(chip => chip.classList.remove('is-downloaded'));
+    document.querySelectorAll('.key-filter-row').forEach(row => row.classList.remove('is-downloaded'));
     OSM_KEY_FILTERS.forEach(key => {
         const chip = document.querySelector('label[for="filter-key-' + key + '"]');
         chip.title = 'Only download changes that touch the ' + key + ' key';

--- a/js/site.js
+++ b/js/site.js
@@ -510,6 +510,7 @@ function run() {
                         imageryUsed: [],
                         leafletFeatureGroup: L.featureGroup(), // Logical group, not added to map
                         osmEditor: '',
+                        osmKeys: new Set(), // OSM keys present on features in this changeset
                         possibleVandalism: false,
                         time: new Date(layer.feature.properties.meta.timestamp),
                         user: layer.feature.properties.meta.user,
@@ -518,6 +519,9 @@ function run() {
                 }
                 //Add the layer to their respective changeset feature groups in changesets
                 changesets[changesetNumber].leafletFeatureGroup.addLayer(layer);
+                // Remember which OSM keys this changeset touches (used by the key filters)
+                const featureTags = getFeatureTags(layer.feature);
+                Object.keys(featureTags).forEach(key => changesets[changesetNumber].osmKeys.add(key));
 
                 // Assign a unique layer ID to each Leaflet layer using the OSM feature ID, appended with 'o' for old features and 'n' for new ones.
                 const OsmIdOfHoveredElement = feature.properties.id;//OSM element ID
@@ -622,6 +626,8 @@ function run() {
             //Reset display of "filter-red-checkbox" (in case it has been checked on a previous download)
             document.querySelector(".traffic-light-filter").classList.add("filter-red-color");
             document.querySelector("#filter-red-checkbox").checked = false;
+            //Reset OSM key filters (in case they have been checked on a previous download)
+            resetOsmKeyFilters();
 
             //Compare length and position of hovered and twin element.
             //return true: Geometry has been changed
@@ -1814,14 +1820,57 @@ function highlightSearchTermInText(text, searchTerm) {
     return { highlightedText, matchFound };
 }
 
+const OSM_KEY_FILTERS = ['building', 'highway', 'landuse'];
+
+// OSM tags live on feature.properties.tags (osmtogeojson default)
+function getFeatureTags(feature) {
+    if (!feature || !feature.properties) return {};
+    return feature.properties.tags || {};
+}
+
+function featureHasAnyOsmKey(feature, keys) {
+    if (!keys.length) return true;
+    const tags = getFeatureTags(feature);
+    return keys.some(key => Object.prototype.hasOwnProperty.call(tags, key));
+}
+
+function getSelectedOsmKeys() {
+    return OSM_KEY_FILTERS.filter(key => {
+        const checkbox = document.getElementById('filter-key-' + key);
+        return checkbox && checkbox.checked;
+    });
+}
+
+function resetOsmKeyFilters() {
+    OSM_KEY_FILTERS.forEach(key => {
+        const checkbox = document.getElementById('filter-key-' + key);
+        if (checkbox) checkbox.checked = false;
+    });
+}
+
+function changesetTouchesOsmKeys(changesetData, keys) {
+    if (!keys.length) return true;
+    if (changesetData.osmKeys instanceof Set) {
+        return keys.some(key => changesetData.osmKeys.has(key));
+    }
+    let found = false;
+    if (changesetData.leafletFeatureGroup) {
+        changesetData.leafletFeatureGroup.eachLayer(layer => {
+            if (!found && featureHasAnyOsmKey(layer.feature, keys)) found = true;
+        });
+    }
+    return found;
+}
+
 //Filter changesets and update changesets list and GeoJSON data on map
 function filterChangesets() {
     let foundChangesets = {}; // This will store data for rendering (potentially with highlighted text)
     const searchTerm = document.querySelector(".search-changesets-field").value.toLowerCase();
     const onlyRed = document.querySelector("#filter-red-checkbox").checked;
+    const selectedKeys = getSelectedOsmKeys();
 
-    // If searchTerm is empty AND "onlyRed" is not checked, show all changesets by writing all the data from 'changesets' object into 'foundChangesets'
-    if (!searchTerm && !onlyRed) {
+    // If searchTerm is empty AND "onlyRed" is not checked AND no OSM key is selected, show all changesets
+    if (!searchTerm && !onlyRed && selectedKeys.length === 0) {
         for (const changesetId in changesets) {
             // Ensure we are only processing actual changeset entries, not 'allLeafletLayers'
             if (changesets.hasOwnProperty(changesetId) && changesetId !== 'allLeafletLayers') {
@@ -1840,6 +1889,9 @@ function filterChangesets() {
 
         // Apply "onlyRed" filter first. If it's active and current changeset is not marked as 'possible vandalism', skip.
         if (onlyRed && !currentChangesetData.possibleVandalism) continue;
+
+        // Apply OSM key filter. Keep the changeset if it touches at least one selected key (OR logic).
+        if (!changesetTouchesOsmKeys(currentChangesetData, selectedKeys)) continue;
 
         let matchFoundBySearchTerm = false;
         let modifiedComment = currentChangesetData.comment || ""; // Start with original or empty string
@@ -1862,9 +1914,9 @@ function filterChangesets() {
         }
 
         // Determine if this changeset should be included in results:
-        // - If searchTerm is entered AND matchFoundBySearchTerm must be true.
-        // - If searchTerm is NOT entered BUT onlyRed IS (due to initial check)
-        if ((searchTerm && matchFoundBySearchTerm) || (!searchTerm && onlyRed)) {
+        // - If searchTerm is entered, a comment/user match is required.
+        // - If searchTerm is NOT entered, the red-light and/or OSM key filters already applied above are enough.
+        if ((searchTerm && matchFoundBySearchTerm) || !searchTerm) {
             foundChangesets[changesetId] = {
                 ...currentChangesetData, // Copy all original properties
                 user: modifiedUserName,    // Override with (potentially) highlighted user
@@ -1874,11 +1926,12 @@ function filterChangesets() {
     }
     // console.table(foundChangesets);
     renderChangesetsList(foundChangesets); // Pass the object with potentially highlighted text
-    displayGeoJson(foundChangesets);
+    displayGeoJson(foundChangesets, selectedKeys);
 
     //Filter GeoJSON on map
-    function displayGeoJson(fSets) { // fSets is the foundChangesets object
+    function displayGeoJson(fSets, keysToShow) { // fSets is the foundChangesets object
         if (!changesets.allLeafletLayers) return;
+        const visibleKeys = keysToShow || [];
 
         // Clear layers. Important: The layers are just detached from the map. The reference to those layers
         // inside 'changesets[csId].leafletFeatureGroup' is still intact.
@@ -1892,7 +1945,9 @@ function filterChangesets() {
                 const originalChangesetData = changesets[csId];
                 if (originalChangesetData && originalChangesetData.leafletFeatureGroup) {
                     originalChangesetData.leafletFeatureGroup.eachLayer(layer => {
-                        visibleLayers.push(layer);
+                        if (featureHasAnyOsmKey(layer.feature, visibleKeys)) {
+                            visibleLayers.push(layer);
+                        }
                     });
                 }
             }
@@ -2018,6 +2073,11 @@ document.querySelector(".delete-filter-input").addEventListener("click", () => {
 document.querySelector("#filter-red-checkbox").addEventListener("click", (e) => {
     document.querySelector(".traffic-light-filter").classList.toggle("filter-red-color");
     filterChangesets();
+});
+
+// Filter changesets and map features by OSM key (building, highway, landuse)
+document.querySelectorAll(".key-filter-checkbox").forEach(checkbox => {
+    checkbox.addEventListener("change", filterChangesets);
 });
 
 //Display "Back-to-top" button if changesets in sidebar are overflowing and user scrolled down a bit

--- a/js/site.js
+++ b/js/site.js
@@ -292,6 +292,10 @@ const vandalismThreshold = -3; //If 3 more elements or tags have been deleted th
 const debugMode = false; //False (default): Do an API call to Overpass. True: Use locally saved xml files for debugging/development purposes
 const OSM_KEY_FILTERS = ['building', 'highway', 'landuse'];
 
+function getAllKeysCheckbox() {
+    return document.getElementById('filter-key-all');
+}
+
 function getSelectedOsmKeys() {
     return OSM_KEY_FILTERS.filter(key => {
         const checkbox = document.getElementById('filter-key-' + key);
@@ -299,15 +303,40 @@ function getSelectedOsmKeys() {
     });
 }
 
+function isAllKeysMode() {
+    const allBox = getAllKeysCheckbox();
+    return !getSelectedOsmKeys().length && (!allBox || allBox.checked);
+}
+
+function setKeyCheckbox(key, checked) {
+    const checkbox = document.getElementById('filter-key-' + key);
+    if (checkbox) checkbox.checked = checked;
+}
+
+function applyExclusiveKeySelection(changedKey) {
+    if (changedKey === 'all') {
+        if (getAllKeysCheckbox().checked) {
+            OSM_KEY_FILTERS.forEach(key => setKeyCheckbox(key, false));
+        } else if (!getSelectedOsmKeys().length) {
+            // Keep at least one mode selected: fall back to all
+            getAllKeysCheckbox().checked = true;
+        }
+    } else if (getSelectedOsmKeys().length) {
+        getAllKeysCheckbox().checked = false;
+    } else {
+        getAllKeysCheckbox().checked = true;
+    }
+}
+
 function keysFromUrl() {
     const raw = new URLSearchParams(location.search).get('keys') || '';
-    return raw.split(',').map(key => key.trim()).filter(key => OSM_KEY_FILTERS.includes(key));
+    return raw.split(',').map(key => key.trim()).filter(key => key === 'all' || OSM_KEY_FILTERS.includes(key));
 }
 
 function syncOsmKeysInUrl(keys) {
     const url = new URL(location.href);
-    if (keys.length) url.searchParams.set('keys', keys.join(','));
-    else url.searchParams.delete('keys');
+    const value = (!keys.length || keys[0] === 'all') ? 'all' : keys.join(',');
+    url.searchParams.set('keys', value);
     history.replaceState(history.state, '', url);
 }
 
@@ -317,7 +346,7 @@ function setKeyFilterCaption(text) {
 }
 
 function persistOsmKeyFilters() {
-    const keys = getSelectedOsmKeys();
+    const keys = isAllKeysMode() ? ['all'] : getSelectedOsmKeys();
     localStorage.setItem('osm-key-filters', JSON.stringify(keys));
     syncOsmKeysInUrl(keys);
 }
@@ -330,48 +359,49 @@ function restoreOsmKeyFilters() {
             try {
                 const parsed = JSON.parse(stored);
                 if (Array.isArray(parsed)) {
-                    keys = parsed.filter(key => OSM_KEY_FILTERS.includes(key));
+                    keys = parsed.filter(key => key === 'all' || OSM_KEY_FILTERS.includes(key));
                 }
             } catch (e) {
                 // Ignore invalid localStorage content
             }
         }
     }
-    OSM_KEY_FILTERS.forEach(key => {
-        const checkbox = document.getElementById('filter-key-' + key);
-        if (checkbox) checkbox.checked = keys.includes(key);
-    });
+    const useAll = !keys.length || keys.includes('all');
+    getAllKeysCheckbox().checked = useAll;
+    OSM_KEY_FILTERS.forEach(key => setKeyCheckbox(key, !useAll && keys.includes(key)));
     persistOsmKeyFilters();
 }
 
 function lockUnusedKeyFilters(downloadedKeys, downloading = false) {
     const wrap = document.querySelector('.key-filter-wrap');
+    const downloadedAll = downloadedKeys.length === 0;
     wrap.classList.toggle('is-downloading', downloading);
-    wrap.classList.toggle('is-locked', downloadedKeys.length > 0);
+    wrap.classList.add('is-locked');
+    const allRow = document.querySelector('label[for="filter-key-all"]');
+    allRow.classList.toggle('is-downloaded', downloadedAll);
+    allRow.title = downloadedAll
+        ? 'Included in this download'
+        : 'Not downloaded. Click to download all keys next';
     OSM_KEY_FILTERS.forEach(key => {
-        const chip = document.querySelector('label[for="filter-key-' + key + '"]');
+        const row = document.querySelector('label[for="filter-key-' + key + '"]');
         const used = downloadedKeys.includes(key);
-        chip.classList.toggle('is-downloaded', used);
-        chip.title = used
+        row.classList.toggle('is-downloaded', used);
+        row.title = used
             ? 'Included in this download'
-            : downloadedKeys.length
-                ? 'Not downloaded. Click to include in the next download'
-                : 'Only download changes that touch the ' + key + ' key';
+            : 'Not downloaded. Click to include in the next download';
     });
-    if (downloadedKeys.length) {
-        setKeyFilterCaption('Downloaded: ' + downloadedKeys.join(', '));
-    } else {
-        setKeyFilterCaption('Select keys before download');
-    }
+    setKeyFilterCaption(downloadedAll ? 'Downloaded: all' : 'Downloaded: ' + downloadedKeys.join(', '));
 }
 
 function unlockKeyFiltersForEditing() {
     const wrap = document.querySelector('.key-filter-wrap');
     wrap.classList.remove('is-locked', 'is-downloading');
     document.querySelectorAll('.key-filter-row').forEach(row => row.classList.remove('is-downloaded'));
+    getAllKeysCheckbox().title = 'Download all changes, without filtering by OSM key';
+    document.querySelector('label[for="filter-key-all"]').title = 'Download all changes, without filtering by OSM key';
     OSM_KEY_FILTERS.forEach(key => {
-        const chip = document.querySelector('label[for="filter-key-' + key + '"]');
-        chip.title = 'Only download changes that touch the ' + key + ' key';
+        const row = document.querySelector('label[for="filter-key-' + key + '"]');
+        row.title = 'Only download changes that touch the ' + key + ' key';
     });
     setKeyFilterCaption('Select keys before download');
 }
@@ -2141,7 +2171,10 @@ document.querySelectorAll(".key-filter-checkbox").forEach(checkbox => {
             setKeyFilterCaption('Click Get Changesets to apply');
         }
     });
-    checkbox.addEventListener("change", persistOsmKeyFilters);
+    checkbox.addEventListener("change", () => {
+        applyExclusiveKeySelection(checkbox.dataset.key);
+        persistOsmKeyFilters();
+    });
 });
 
 //Display "Back-to-top" button if changesets in sidebar are overflowing and user scrolled down a bit

--- a/js/site.js
+++ b/js/site.js
@@ -290,6 +290,44 @@ const overpassServers = [
 ];
 const vandalismThreshold = -3; //If 3 more elements or tags have been deleted than added, the traffic light will change to red
 const debugMode = false; //False (default): Do an API call to Overpass. True: Use locally saved xml files for debugging/development purposes
+const OSM_KEY_FILTERS = ['building', 'highway', 'landuse'];
+
+function getSelectedOsmKeys() {
+    return OSM_KEY_FILTERS.filter(key => {
+        const checkbox = document.getElementById('filter-key-' + key);
+        return checkbox && checkbox.checked;
+    });
+}
+
+function persistOsmKeyFilters() {
+    localStorage.setItem('osm-key-filters', JSON.stringify(getSelectedOsmKeys()));
+}
+
+function restoreOsmKeyFilters() {
+    const stored = localStorage.getItem('osm-key-filters');
+    if (!stored) return;
+    try {
+        const keys = JSON.parse(stored);
+        if (!Array.isArray(keys)) return;
+        OSM_KEY_FILTERS.forEach(key => {
+            const checkbox = document.getElementById('filter-key-' + key);
+            if (checkbox) checkbox.checked = keys.includes(key);
+        });
+    } catch (e) {
+        // Ignore invalid localStorage content
+    }
+}
+
+// Build the Overpass adiff query. Selected keys are applied server-side so unused objects are never downloaded.
+function buildOverpassQuery(bbox) {
+    const header = '[adiff:"' + calculateAnalysisStartTime().toISOString() + '"][bbox:' + bbox + '][out:xml];';
+    const keys = getSelectedOsmKeys();
+    if (!keys.length) {
+        return header + 'nw;out geom meta;';
+    }
+    const union = keys.map(key => 'nw["' + key + '"];').join('');
+    return header + '(' + union + ');out geom meta;';
+}
 
 // Reset AbortController to null during load of script. Needed to reset all Promise requests.
 window.currentAbortController = null;
@@ -298,6 +336,7 @@ window.currentAbortController = null;
 let changesets = {};
 
 //Check if map is zoomed in enough (only executed on initial page load)
+restoreOsmKeyFilters();
 const isMapZoomedInEnough = updateMap();
 if (isMapZoomedInEnough) run();
 
@@ -332,7 +371,7 @@ function run() {
         bounds.getNorthEast().lat + ',' +
         bounds.getNorthEast().wrap().lng;
     // const overpass_query = '[adiff:"' + calculateAnalysisStartTime() + '"][bbox:' + bbox + '][out:xml][timeout:22];way->.ways;(.ways>;node;);out meta;.ways out geom meta;';//This query sometimes only returned nodes. Thus replaced with query below
-    const overpass_query = '[adiff:"' + calculateAnalysisStartTime().toISOString() + '"][bbox:' + bbox + '][out:xml];nw;out geom meta;';
+    const overpass_query = buildOverpassQuery(bbox);
     // console.log(overpass_server + 'interpreter?data=' + overpass_query);
 
     let allOverpassXMLDataElements;
@@ -626,8 +665,6 @@ function run() {
             //Reset display of "filter-red-checkbox" (in case it has been checked on a previous download)
             document.querySelector(".traffic-light-filter").classList.add("filter-red-color");
             document.querySelector("#filter-red-checkbox").checked = false;
-            //Reset OSM key filters (in case they have been checked on a previous download)
-            resetOsmKeyFilters();
 
             //Compare length and position of hovered and twin element.
             //return true: Geometry has been changed
@@ -1820,46 +1857,10 @@ function highlightSearchTermInText(text, searchTerm) {
     return { highlightedText, matchFound };
 }
 
-const OSM_KEY_FILTERS = ['building', 'highway', 'landuse'];
-
 // OSM tags live on feature.properties.tags (osmtogeojson default)
 function getFeatureTags(feature) {
     if (!feature || !feature.properties) return {};
     return feature.properties.tags || {};
-}
-
-function featureHasAnyOsmKey(feature, keys) {
-    if (!keys.length) return true;
-    const tags = getFeatureTags(feature);
-    return keys.some(key => Object.prototype.hasOwnProperty.call(tags, key));
-}
-
-function getSelectedOsmKeys() {
-    return OSM_KEY_FILTERS.filter(key => {
-        const checkbox = document.getElementById('filter-key-' + key);
-        return checkbox && checkbox.checked;
-    });
-}
-
-function resetOsmKeyFilters() {
-    OSM_KEY_FILTERS.forEach(key => {
-        const checkbox = document.getElementById('filter-key-' + key);
-        if (checkbox) checkbox.checked = false;
-    });
-}
-
-function changesetTouchesOsmKeys(changesetData, keys) {
-    if (!keys.length) return true;
-    if (changesetData.osmKeys instanceof Set) {
-        return keys.some(key => changesetData.osmKeys.has(key));
-    }
-    let found = false;
-    if (changesetData.leafletFeatureGroup) {
-        changesetData.leafletFeatureGroup.eachLayer(layer => {
-            if (!found && featureHasAnyOsmKey(layer.feature, keys)) found = true;
-        });
-    }
-    return found;
 }
 
 //Filter changesets and update changesets list and GeoJSON data on map
@@ -1867,10 +1868,9 @@ function filterChangesets() {
     let foundChangesets = {}; // This will store data for rendering (potentially with highlighted text)
     const searchTerm = document.querySelector(".search-changesets-field").value.toLowerCase();
     const onlyRed = document.querySelector("#filter-red-checkbox").checked;
-    const selectedKeys = getSelectedOsmKeys();
 
-    // If searchTerm is empty AND "onlyRed" is not checked AND no OSM key is selected, show all changesets
-    if (!searchTerm && !onlyRed && selectedKeys.length === 0) {
+    // If searchTerm is empty AND "onlyRed" is not checked, show all changesets by writing all the data from 'changesets' object into 'foundChangesets'
+    if (!searchTerm && !onlyRed) {
         for (const changesetId in changesets) {
             // Ensure we are only processing actual changeset entries, not 'allLeafletLayers'
             if (changesets.hasOwnProperty(changesetId) && changesetId !== 'allLeafletLayers') {
@@ -1889,9 +1889,6 @@ function filterChangesets() {
 
         // Apply "onlyRed" filter first. If it's active and current changeset is not marked as 'possible vandalism', skip.
         if (onlyRed && !currentChangesetData.possibleVandalism) continue;
-
-        // Apply OSM key filter. Keep the changeset if it touches at least one selected key (OR logic).
-        if (!changesetTouchesOsmKeys(currentChangesetData, selectedKeys)) continue;
 
         let matchFoundBySearchTerm = false;
         let modifiedComment = currentChangesetData.comment || ""; // Start with original or empty string
@@ -1914,9 +1911,9 @@ function filterChangesets() {
         }
 
         // Determine if this changeset should be included in results:
-        // - If searchTerm is entered, a comment/user match is required.
-        // - If searchTerm is NOT entered, the red-light and/or OSM key filters already applied above are enough.
-        if ((searchTerm && matchFoundBySearchTerm) || !searchTerm) {
+        // - If searchTerm is entered AND matchFoundBySearchTerm must be true.
+        // - If searchTerm is NOT entered BUT onlyRed IS (due to initial check)
+        if ((searchTerm && matchFoundBySearchTerm) || (!searchTerm && onlyRed)) {
             foundChangesets[changesetId] = {
                 ...currentChangesetData, // Copy all original properties
                 user: modifiedUserName,    // Override with (potentially) highlighted user
@@ -1926,12 +1923,11 @@ function filterChangesets() {
     }
     // console.table(foundChangesets);
     renderChangesetsList(foundChangesets); // Pass the object with potentially highlighted text
-    displayGeoJson(foundChangesets, selectedKeys);
+    displayGeoJson(foundChangesets);
 
     //Filter GeoJSON on map
-    function displayGeoJson(fSets, keysToShow) { // fSets is the foundChangesets object
+    function displayGeoJson(fSets) { // fSets is the foundChangesets object
         if (!changesets.allLeafletLayers) return;
-        const visibleKeys = keysToShow || [];
 
         // Clear layers. Important: The layers are just detached from the map. The reference to those layers
         // inside 'changesets[csId].leafletFeatureGroup' is still intact.
@@ -1945,9 +1941,7 @@ function filterChangesets() {
                 const originalChangesetData = changesets[csId];
                 if (originalChangesetData && originalChangesetData.leafletFeatureGroup) {
                     originalChangesetData.leafletFeatureGroup.eachLayer(layer => {
-                        if (featureHasAnyOsmKey(layer.feature, visibleKeys)) {
-                            visibleLayers.push(layer);
-                        }
+                        visibleLayers.push(layer);
                     });
                 }
             }
@@ -2075,9 +2069,9 @@ document.querySelector("#filter-red-checkbox").addEventListener("click", (e) => 
     filterChangesets();
 });
 
-// Filter changesets and map features by OSM key (building, highway, landuse)
+// OSM key chips are query parameters: persist them and apply on the next download
 document.querySelectorAll(".key-filter-checkbox").forEach(checkbox => {
-    checkbox.addEventListener("change", filterChangesets);
+    checkbox.addEventListener("change", persistOsmKeyFilters);
 });
 
 //Display "Back-to-top" button if changesets in sidebar are overflowing and user scrolled down a bit


### PR DESCRIPTION
## Summary
- Add `all` / `building` / `highway` / `landuse` switches above **Get Changesets**.
- Selected keys are sent in the Overpass query, so unused objects are not downloaded. The existing sidebar search and vandalism filter still run after the data is loaded.
- Unused keys are greyed out after a download. The selection is stored as `?keys=` so a view can be bookmarked.

## Example

URL: `/latest-changes/?keys=highway#12/44.1536/4.8910`

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/adb22b1d-896c-4353-aeed-f1a003012c27" />


## Test plan
- [ ] Zoom in past z11, leave **all** on, click **Get Changesets**.
- [ ] Switch to **highway** only, download again, and check that buildings and landuse are not fetched.
- [ ] Confirm `?keys=highway` appears in the URL and still works after a reload.
- [ ] After a download, confirm unused switches are greyed out and that **Filter changesets** still filters the loaded list.